### PR TITLE
build.bat: fix exit

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,5 +1,5 @@
 @echo off
 
-where /q python || echo Python not found. & goto EOF
+where /q python || echo Python not found. & goto :EOF
 
 python tool %*


### PR DESCRIPTION
Add colon `:` before EOF