### PR TITLE
set CRLF line ending for .bat files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text eol=lf
+*.bat eol=crlf
 
 *.png binary
 *.jpg binary


### PR DESCRIPTION
Set CRLF line ending for .bat files specifically. Or all files including the `build.bat` file can become LF depending on user setup.