### PR TITLE
fix: make build.bat CRLF again

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,5 +1,5 @@
 @echo off
 
-where /q python || echo Python not found. & goto :EOF
+where /q python || echo Python not found. & exit /b %errorlevel%
 
 python tool %*


### PR DESCRIPTION
sha256sum of build.bat:

```
8c764e929a7ab92c23d750e88f49542ed567aa031f60cbcd19f6002f30fb8b47
```

Please make sure to match the hash locally before pushing to remote.
