### PR TITLE
build.bat fix (again) and set default platform to Merged

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
       platform:
         description: 'platform'
         required: true
-        default: 'All'
+        default: 'Merged'
         type: choice
         options:
         - Android

--- a/build.bat
+++ b/build.bat
@@ -1,5 +1,5 @@
 @echo off
 
-where /q python || echo Python not found. & exit /b %errorlevel%
+where /q python || (echo Python not found. & exit /b %errorlevel%)
 
 python tool %*


### PR DESCRIPTION
* I am extremely sorry for the previous mistakes. I had been testing ci on main branch (which is way behind) instead of this branch.
* I think it's better to encourage devs to use Merged version instead of doing all platforms separately. As many users don't realize that shaders need to support platform first.

Also a suggestion: A better name for `merged`. Currently, this word doesn't make any sense to those who are not familiar with shaders. You can use `allplatform` but I guess that would confuse Xbox/Switch users.

