### PR TITLE
Improvement with rounded clouds. (Added dithering/hash effect to displace rounded clouds cuts)

### DIFF
--- a/src/materials/Clouds/fragment.sc
+++ b/src/materials/Clouds/fragment.sc
@@ -7,7 +7,7 @@ $input v_color0
 #include <bgfx_shader.sh>
 #include <newb/main.sh>
 
-#define NL_CLOUD_PARAMS(x) NL_CLOUD2##x##STEPS, NL_CLOUD2##x##THICKNESS, NL_CLOUD2##x##RAIN_THICKNESS, NL_CLOUD2##x##VELOCITY, NL_CLOUD2##x##SCALE, NL_CLOUD2##x##DENSITY, NL_CLOUD2##x##SHAPE
+#define NL_CLOUD_PARAMS(x) NL_CLOUD2##x##THICKNESS, NL_CLOUD2##x##RAIN_THICKNESS, NL_CLOUD2##x##VELOCITY, NL_CLOUD2##x##SCALE, NL_CLOUD2##x##DENSITY, NL_CLOUD2##x##SHAPE
 
 void main() {
   vec4 color = v_color0;

--- a/src/newb/config.h
+++ b/src/newb/config.h
@@ -133,7 +133,6 @@
 /* Rounded cloud settings */
 #define NL_CLOUD2_THICKNESS 2.1            // 0.5 slim ~ 5.0 fat
 #define NL_CLOUD2_RAIN_THICKNESS 2.5       // 0.5 slim ~ 5.0 fat
-#define NL_CLOUD2_STEPS 5                  // 3 low quality ~ 16 high quality
 #define NL_CLOUD2_SCALE vec2(0.033, 0.033) // 0.003 large ~ 0.3 tiny
 #define NL_CLOUD2_SHAPE vec2(0.5, 0.4)     // 0.0 round ~ 1.0 box vec2(horizontal shape, vertical shape)
 #define NL_CLOUD2_DENSITY 25.0             // 1.0 blurry ~ 100.0 sharp
@@ -142,7 +141,6 @@
 #define NL_CLOUD2_LAYER2_OFFSET 143.0           // 30.0 near ~ 300.0 very high
 #define NL_CLOUD2_LAYER2_THICKNESS 2.5          // 0.7 slim ~ 5.0 fat
 #define NL_CLOUD2_LAYER2_RAIN_THICKNESS 3.0     // 0.7 slim ~ 5.0 fat
-#define NL_CLOUD2_LAYER2_STEPS 3                // 3 low quality ~ 16 high quality
 #define NL_CLOUD2_LAYER2_SCALE vec2(0.03, 0.03) // 0.003 large ~ 0.3 tiny
 #define NL_CLOUD2_LAYER2_SHAPE vec2(0.5, 0.4)   // 0.0 round ~ 1.0 box vec2(horizontal shape, vertical shape)
 #define NL_CLOUD2_LAYER2_DENSITY 25.0           // 1.0 blurry ~ 100.0 sharp

--- a/src/newb/functions/clouds.h
+++ b/src/newb/functions/clouds.h
@@ -57,13 +57,13 @@ float cloudDf(vec3 pos, float rain, vec2 boxiness) {
   return n;
 }
 
+
 vec4 renderCloudsRounded(
-    vec3 vDir, vec3 vPos, float rain, float time, vec3 horizonCol, vec3 zenithCol,
-    const int steps, const float thickness, const float thickness_rain, const float speed,
+    vec3 vDir, vec3 vPos, float rain, float time, vec3 horizonCol, vec3 zenithCol, const float thickness, const float thickness_rain, const float speed,
     const vec2 scale, const float density, const vec2 boxiness
 ) {
   float height = 7.0*mix(thickness, thickness_rain, rain);
-  float stepsf = float(steps);
+  float stepsf = 6.0;
 
   // scaled ray offset
   vec3 deltaP;
@@ -77,10 +77,11 @@ vec4 renderCloudsRounded(
   pos += deltaP;
 
   deltaP /= -stepsf;
+  pos += deltaP * hash(vPos.xz + time); // Displace Clouds' Step
 
   // alpha, gradient
   vec2 d = vec2(0.0,1.0);
-  for (int i=1; i<=steps; i++) {
+  for (int i=1; i<=int(stepsf); i++) {
     float m = cloudDf(pos, rain, boxiness);
     d.x += m;
     d.y = mix(d.y, pos.y, m);
@@ -143,20 +144,20 @@ vec4 renderClouds(vec2 p, float t, float rain, vec3 horizonCol, vec3 zenithCol, 
 
 // aurora is rendered on clouds layer
 #ifdef NL_AURORA
-vec4 renderAurora(vec3 p, float t, float rain, vec3 FOG_COLOR) {
-  t *= NL_AURORA_VELOCITY;
-  p.xz *= NL_AURORA_SCALE;
-  p.xz += 0.05*sin(p.x*4.0 + 20.0*t);
+  vec4 renderAurora(vec3 p, float t, float rain, vec3 FOG_COLOR) {
+    t *= NL_AURORA_VELOCITY;
+    p.xz *= NL_AURORA_SCALE;
+    p.xz += 0.05*sin(p.x*4.0 + 20.0*t);
 
-  float d0 = sin(p.x*0.1 + t + sin(p.z*0.2));
-  float d1 = sin(p.z*0.1 - t + sin(p.x*0.2));
-  float d2 = sin(p.z*0.1 + 1.0*sin(d0 + d1*2.0) + d1*2.0 + d0*1.0);
-  d0 *= d0; d1 *= d1; d2 *= d2;
-  d2 = d0/(1.0 + d2/NL_AURORA_WIDTH);
+    float d0 = sin(p.x*0.1 + t + sin(p.z*0.2));
+    float d1 = sin(p.z*0.1 - t + sin(p.x*0.2));
+    float d2 = sin(p.z*0.1 + 1.0*sin(d0 + d1*2.0) + d1*2.0 + d0*1.0);
+    d0 *= d0; d1 *= d1; d2 *= d2;
+    d2 = d0/(1.0 + d2/NL_AURORA_WIDTH);
 
-  float mask = (1.0-0.8*rain)*max(1.0 - 4.0*max(FOG_COLOR.b, FOG_COLOR.g), 0.0);
-  return vec4(NL_AURORA*mix(NL_AURORA_COL1,NL_AURORA_COL2,d1),1.0)*d2*mask;
-}
+    float mask = (1.0-0.8*rain)*max(1.0 - 4.0*max(FOG_COLOR.b, FOG_COLOR.g), 0.0);
+    return vec4(NL_AURORA*mix(NL_AURORA_COL1,NL_AURORA_COL2,d1),1.0)*d2*mask;
+  }
 #endif
 
 #endif

--- a/src/newb/functions/noise.h
+++ b/src/newb/functions/noise.h
@@ -80,4 +80,11 @@ float fastVoronoi2(vec2 pos, float f) {
   return 1.0-f*min(p.x+p.y, p.z+p.w);
 }
 
+// Used by renderCloudsRounded() - A hash noise to displace rounded clouds step 
+float hash(vec2 p) {
+  p = fract(p*vec2(123.45, 678.12));
+  p += dot(p, p + 50.0);
+  return fract(p.x*p.y);
+}
+
 #endif


### PR DESCRIPTION
I have added dithering/hash effects to displace the cuts between the rounded clouds. I have also set the steps to constant 6.0 as they don't need to change it. However, increasing the steps can decrease both dithering and performance (as everyone knows).

This improvement removes the oddly looks (cuts in-between) and performance as they don't need to increase steps to improve the quality or remove the cuts of the rounded clouds.

You may check how it affect the clouds (Video):
[Screencast from 2025-08-03 21-44-38.webm](https://github.com/user-attachments/assets/7b3e6156-89c7-45e9-b324-982ac5e7472a)
