### PR TITLE
Bump required lazurite and game version for v1.26.0+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-lazurite==0.6.0
+lazurite==0.8.3
 rich==13.7.1

--- a/src/newb/pack_config.toml
+++ b/src/newb/pack_config.toml
@@ -1,6 +1,6 @@
 name = "Newb X Legacy"
 version = [0, 16, 0]
-min_supported_mc_version = [1, 21, 130]
+min_supported_mc_version = [1, 26, 0]
 description = '''
 §c%w
 §7- An enchanced vanilla shader for Minecraft!

--- a/tool/setup.py
+++ b/tool/setup.py
@@ -106,7 +106,7 @@ def run(args):
         if not os.path.exists(test_mat):
             progress.console.print("Downloading source materials")
             mat_filename = os.path.join(data_path, 'materials.zip')
-            _download_file(NS_DEV_RELEASE + "src-materials-1.21.111.zip", mat_filename)
+            _download_file(NS_DEV_RELEASE + "src-materials-1.26.0.zip", mat_filename)
             with zipfile.ZipFile(mat_filename, 'r') as zip_ref:
                 zip_ref.extractall(mat_path)
             os.remove(mat_filename)


### PR DESCRIPTION
- Also change the target src-materials download file name

You can upload this in the dependency repo: [src-materials-1.26.0.zip](https://github.com/user-attachments/files/25218918/src-materials-1.26.0.zip)