### PR TITLE
Update pack_config.toml and pack.py for 1.26.30 and iOS

### DIFF
--- a/src/newb/pack_config.toml
+++ b/src/newb/pack_config.toml
@@ -1,14 +1,14 @@
 name = "Newb Classic"
-version = [0, 16, 52]
-min_supported_mc_version = [1, 26, 10]
+version = [0, 16, 53]
+min_supported_mc_version = [1, 26, 30]
 description = '''
 §c%w
 §7- An enchanced vanilla shader for Minecraft!
 %v
-§3https://devendrn.github.io/newb-shader/
+§3https://newb-shader.devendrn.com/
 ''' # %w = patch warning, %v = version
 authors = ["devendrn"]
-url = "https://devendrn.github.io/newb-shader/"
+url = "https://newb-shader.devendrn.com/"
 uuid = "95f774cf-4afa-73e7-a21a-72146307b1d2" # Use https://www.uuidgenerator.net/version4
 materials = ["Sky", "RenderChunk", "Actor", "ActorGlint", "EndSky", "Clouds", "SunMoon", "Weather", "ItemInHandTextured", "ItemInHandColor", "ItemInHandColorGlint", "Stars"]
 

--- a/tool/pack.py
+++ b/tool/pack.py
@@ -155,12 +155,12 @@ def run(args):
     patch_warning = "Only works with "
     if profile == 'android':
         patch_warning += "MB Loader"
+    if profile == 'ios':
+        patch_warning += "Minecraft with Hynis"
     elif profile == 'windows':
         patch_warning += "BetterRenderDragon"
     elif profile == 'merged':
-        patch_warning += "MB Loader (Android) or BetterRenderDragon (Windows)\nFor iOS, materials need to be installed manually for shader to work"
-    else:  # ios
-        patch_warning = "Materials need to be installed manually for shader to work"
+        patch_warning += "MB Loader (Android) or BetterRenderDragon (Windows) or Minecraft with Hynis (iOS)"
 
     pack_description = pack_description.replace("%w", patch_warning).replace("%v", "v" + pack_version + "-" + args.p)
     pack_config['description'] = pack_description
@@ -198,10 +198,6 @@ def run(args):
 
     status.stop()
 
-    is_ios = args.p == 'ios'
-    if is_ios:
-        pack_manifest.pop('subpacks')
-
     with open(os.path.join(pack_dir, 'manifest.json'), 'w') as f:
         json.dump(pack_manifest, f, indent=2)
 
@@ -216,8 +212,7 @@ def run(args):
             f.write(pack_credits)
 
     if not args.no_zip:
-        pack_archive = os.path.join('build', pack_acr_name + ('.zip' if is_ios else '.mcpack'))
+        pack_archive = os.path.join('build', pack_acr_name + '.mcpack')
         console.print("\n~ [bold]Archive pack\n ", pack_archive)
         shutil.make_archive(pack_dir, 'zip', pack_dir)
-        if not is_ios:
-            os.rename(pack_dir + '.zip', pack_archive)
+        os.rename(pack_dir + '.zip', pack_archive)


### PR DESCRIPTION
Adjusted `pack_config.toml` (manifest) for Minecraft v1.26.30.

Since Minecraft with Hynis on iOS behaves similarly to MB Loader and BetterRenderDragon, I have adjusted the `patch_warning` text accordingly as well as remove iOS related conditionals from `pack.py` since all supported platforms behave similarly now.

After merging, please run workflow again so I can post files to CF.