### PR TITLE
Replace install method BRD with Wyvern

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ You can download the shader pack from [release page](https://github.com/devendrn
 
 ### Windows
 
-| **Using BRD Mod** |
+| **Using Wyvern Loader** |
 |:-|
-| 1. Use [BetterRenderDragon](https://github.com/QYCottage/BetterRenderDragon/releases/latest) to enable MaterialBinLoader. |
-| 2. Import the resource pack and activate it in global resources. |
+| 1. Download and setup Wyvern from [here](https://github.com/mcbegamerxx954/wyvern_releases/releases/latest) |
+| 2. Open Minecraft then click 'Inject' in Wyvern |
+| 3. Import the resource pack and activate it in global resources. |
 
 ### Linux / Mac
 This method is for [mcpelauncher-manifest](https://minecraft-linux.github.io/).

--- a/tool/pack.py
+++ b/tool/pack.py
@@ -158,9 +158,9 @@ def run(args):
     if profile == 'ios':
         patch_warning += "Minecraft with Hynis"
     elif profile == 'windows':
-        patch_warning += "BetterRenderDragon"
+        patch_warning += "Wyvern Loader"
     elif profile == 'merged':
-        patch_warning += "MB Loader (Android) or BetterRenderDragon (Windows) or Minecraft with Hynis (iOS)"
+        patch_warning += "MB Loader (Android) or Wyvern Loader (Windows) or Minecraft with Hynis (iOS)"
 
     pack_description = pack_description.replace("%w", patch_warning).replace("%v", "v" + pack_version + "-" + args.p)
     pack_config['description'] = pack_description


### PR DESCRIPTION
BetterRenderDragon in it's current nature is prone to break almost everytime a major game update is released. Sometimes core functionality breaks. For example the ImGui stopped working since v26.32.

Since the GDK migration of Minecraft you are basically forced to update the game to latest unless you modify some game files. So an average user has to wait 10-20 days for BRD update.

Wyvern aims to eliminate this issue by not relying on reverse engineering of the game to find correct address to modify in-memory. So, it should be much more stable in the long run and easier to maintain compared to BRD.

I also intend to update the description on CF in the next update for Newb Shader. As of now, Wyvern is slightly unstable but works mostly fine. 