### PR TITLE
Support 1.26.40 texcoord for extra plants wave

### DIFF
--- a/src/newb/functions/wave.h
+++ b/src/newb/functions/wave.h
@@ -40,7 +40,7 @@ void lanternWave(
 
 #ifdef NL_EXTRA_PLANTS_WAVE
 void extraPlantsFlag(inout bool shouldWave, vec2 uv0, bool isTop) {
-  // 1.26.31 (1024x512) vanilla only
+  // 1.26.40 (1024x512) vanilla only
   // not meant to be used
 
   // count texture atlas in left-to-right row wise order (64X32)
@@ -48,25 +48,54 @@ void extraPlantsFlag(inout bool shouldWave, vec2 uv0, bool isTop) {
   int texN = 64*int(uv0.y*32.0) + int(uv0.x*64.0);
 
   if ( // full
-    (texN>184 && texN<187) || // cherrry leaves
-    (texN>452 && texN<462) // tall flowers/plants top
+    (texN>=18 && texN<=20) || // Azeala Leaves and Flowering Azeala Leaves
+    (texN>=177 && texN<=180) || // Cave Vines
+    (texN>=186 && texN<=187) || // Cherrry Leaves (Fixed) 
+    (texN>=444 && texN<=459) || (texN==678) || // tall flowers/plants top
+    (texN>=796 && texN<=797) || // Pale Hanging Moss
+    (texN>=803 && texN<=804) || // Pale Oak Leaves
+    (texN>=832 && texN<=834) || (texN>=837 && texN<=838) // Pitcher Plant
   ) {
     shouldWave = true;
   } else if ( // top only
-    (texN==192) || // cherry blossom sapling
-    (texN==1013) || // spore blossom petal
+    (texN==6) || // Acacia Sappling
+    (texN==8) || // Allium (NEW
+    (texN==25) || // Azure Bluet (NEW
+    (texN==85) || // Birch sappling
+    (texN==110) || // Blue Orchid
+    (texN==145) || // Cactus Flower
+    (texN==192) || // Cherry Blossom Sapling
+    (texN==223) || // Closed Eyeblossom
+    (texN==336) || // Cornflower
+    (texN==387) || // Dandelion
+    (texN==390) || // Dark Oak Sappling
+    (texN==396) || // Dead Bush
     (texN>445 && texN<453) || // tall flowers/plants bottom
-    (texN>1080 && texN<1085) || // sweet berries bush
-    (texN>1091 && texN<1095) || // torch flowers
-    (texN==1189) || // wither rose
-    (texN==389)  || // yellow dandelion
-    (texN==863)  || // red rose
-    (texN>531 && texN<534) // firefly bush
+    (texN>=530 && texN<=531) || // Firefly Bush
+    (texN==564) || // Golden Dandelion
+    (texN==642) || // Jungle Sappling
+    (texN==679) || // Lily of the Valley
+    (texN>=715 && texN<=717) || // Mangrove Propagule
+    (texN==753) || // Oak Sappling
+    (texN>=761 && texN<=763) || // Open Eyeblossom
+    (texN==773) || // Orange Tulip
+    (texN==774) || // Oxeye Daisy
+    (texN==808) || // Pale Oak Sappling
+    (texN==823) || // Pink Tulip (New)
+    (texN==861) || // Poppy
+    (texN==914) || // Red Tulip
+    (texN==915) || // White Tilip
+    (texN==945) ||  // Spruce Sappling
+    (texN==1011) || // Spore Blossom Petal
+    (texN>=1079 && texN<=1082) || // Sweet Berries Bush
+    (texN==1084) || // Tall Dry Grass
+    (texN>=1090 && texN<=1092) || // Torch Flowers
+    (texN==1187) // Wither Rose
   ) {
     shouldWave = isTop;
   } else if ( // bottom only
-    (texN==612) || // hanging roots
-    (texN==23 || texN==549)  // azeala
+    (texN==23 || texN==547) ||  // Azeala
+    (texN==610) // Hanging Roots
   ) { 
     shouldWave = !isTop;
   }


### PR DESCRIPTION
**Supported Flowers:** All excepts Pink Petals and Wildflowers

**Supported Saplings:** All

**Supported Leaves:**
- Cheery Leaves
- Azalea Leaves
- Flowering Azalea Leaves
- Pale Oak leaves

**Supported Bushes:**
- Firefly Bush
- Dead Bush
- Tall Dry Grass
- Sweet Berries
- All tall bushes (I think)

**Supported Hanging Plants:**
- Spore Blossom
- Hanging Roots
- Pale Hanging Roots
- Cave Vines (Glow Berries)

**Other Supported Plants:**
- Azalea
- Flowering Azalea

https://github.com/user-attachments/assets/1c25fcdf-b9fa-4d29-9021-e861580010c4

Reference for 1.26.40:
<img width="6400" height="3200" alt="Untitled design (1)" src="https://github.com/user-attachments/assets/3a10bc66-facd-42c2-be21-c43f145d3dd8" />
