### PR TITLE
Added support for multi-layered textures entities

### DIFF
--- a/src/materials/ActorMultiTexture/config.json
+++ b/src/materials/ActorMultiTexture/config.json
@@ -1,0 +1,46 @@
+{
+  "macro_overwrite": {
+    "flags": {
+      "ColorSecondTexture": {
+        "On":"COLOR_SECOND_TEXTURE",
+        "Off":[]
+      },
+      "Change_Color": {
+        "On": "CHANGE_COLOR",
+        "Multi": "CHANGE_COLOR_MULTI",
+        "Off": []
+      },
+      "Emissive": {
+        "Emissive": "EMISSIVE",
+        "EmissiveOnly": "EMISSIVE_ONLY",
+        "Off": []
+      },
+      "Fancy": {
+        "On": "FANCY",
+        "Off": []
+      },
+      "Instancing": {
+        "On": "INSTANCING",
+        "Off": []
+      },
+      "MaskedMultitexture": {
+        "On": "MASKED_MULTITEXTURE",
+        "Off": []
+      }
+    },
+    "passes": {
+      "AlphaTest": "ALPHA_TEST",
+      "DepthOnly": "DEPTH_ONLY",
+      "DepthOnlyOpaque": "DEPTH_ONLY_OPAQUE",
+      "Opaque": "OPAQUE",
+      "Transparent": "TRANSPARENT"
+    }
+  },
+  "file_overwrite": {
+    "default": {
+      "fragment": "fragment.sc",
+      "vertex": "vertex.sc",
+      "varying": "varying.def.sc"
+    }
+  }
+}

--- a/src/materials/ActorMultiTexture/fragment.sc
+++ b/src/materials/ActorMultiTexture/fragment.sc
@@ -1,0 +1,71 @@
+$input v_color0, v_fog, v_light, v_texcoord0, v_edgemap
+
+#include <bgfx_shader.sh>
+#include <MinecraftRenderer.Materials/ActorUtil.dragonh>
+#include <newb/main.sh>
+
+uniform vec4 ActorFPEpsilon;
+uniform vec4 ColorBased;
+uniform vec4 OverlayColor;
+uniform vec4 ChangeColor;
+uniform vec4 MultiplicativeTintColor;
+uniform vec4 MatColor;
+uniform vec4 TintedAlphaTestEnabled;
+
+SAMPLER2D_AUTOREG(s_MatTexture2);
+SAMPLER2D_AUTOREG(s_MatTexture1);
+SAMPLER2D_AUTOREG(s_MatTexture);
+
+void main() {
+  #if defined(DEPTH_ONLY) || defined(INSTANCING)
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
+    return;
+  #elif defined(DEPTH_ONLY_OPAQUE)
+    gl_FragColor = vec4(mix(vec3_splat(1.0), v_fog.rgb, v_fog.a), 1.0);
+    return;
+  #endif
+
+  vec4 albedo = getActorAlbedoNoColorChange(v_texcoord0, s_MatTexture, s_MatTexture1, MatColor);
+
+  vec4 tex1 = texture2D(s_MatTexture1, v_texcoord0);
+  vec4 tex2 = texture2D(s_MatTexture2, v_texcoord0);
+  albedo = mix(mix(albedo, tex1, tex1.a), tex2, tex2.a);
+
+  #if defined(ALPHA_TEST)
+    float alpha = mix(albedo.a, (albedo.a * OverlayColor.a), TintedAlphaTestEnabled.x);
+    if (shouldDiscard(albedo.rgb, alpha, ActorFPEpsilon.x)) {
+      discard;
+    }
+  #endif
+
+  #ifdef CHANGE_COLOR_MULTI
+    albedo = applyMultiColorChange(albedo, ChangeColor.rgb, MultiplicativeTintColor.rgb);
+  #elif defined(CHANGE_COLOR)
+    albedo = applyColorChange(albedo, ChangeColor, albedo.a);
+    albedo.a *= ChangeColor.a;
+  #endif
+
+  albedo.rgb *= mix(vec3(1.0, 1.0, 1.0), v_color0.rgb, ColorBased.x);
+
+  albedo = applyOverlayColor(albedo, OverlayColor);
+
+  albedo *= albedo;
+
+  vec4 light = v_light;
+
+  #if defined(EMISSIVE) || defined(EMISSIVE_ONLY)
+    light.rgb = max(light.rgb, 2.0*NL_GLOW_TEX*(1.0-albedo.a)); // glow effect
+  #endif
+
+  albedo = applyLighting(albedo, light);
+
+  #ifdef NL_ENTITY_EDGE_HIGHLIGHT
+    albedo.rgb *= nlEntityEdgeHighlight(v_edgemap);
+  #endif
+  
+  albedo.rgb = mix(albedo.rgb, v_fog.rgb, v_fog.a);
+    
+  albedo.rgb = colorCorrection(albedo.rgb);
+
+  gl_FragColor = albedo;
+}

--- a/src/materials/ActorMultiTexture/material.json
+++ b/src/materials/ActorMultiTexture/material.json
@@ -1,0 +1,1 @@
+../../common/material.json

--- a/src/materials/ActorMultiTexture/uniforms
+++ b/src/materials/ActorMultiTexture/uniforms
@@ -1,0 +1,1 @@
+../../common/uniforms/

--- a/src/materials/ActorMultiTexture/varying.def.sc
+++ b/src/materials/ActorMultiTexture/varying.def.sc
@@ -1,0 +1,22 @@
+
+vec4 a_color0    : COLOR0;
+vec4 a_normal    : NORMAL;
+vec3 a_position  : POSITION;
+vec2 a_texcoord0 : TEXCOORD0;
+
+#if BGFX_SHADER_LANGUAGE_HLSL
+int a_indices : BLENDINDICES;
+#else
+float a_indices : BLENDINDICES;
+#endif
+
+vec4 i_data1 : TEXCOORD7;
+vec4 i_data2 : TEXCOORD6;
+vec4 i_data3 : TEXCOORD5;
+
+vec4 v_color0 : COLOR0;
+vec4 v_fog : COLOR1;
+vec4 v_light : COLOR2;
+vec4 v_edgemap : COLOR3;
+
+centroid vec2 v_texcoord0 : TEXCOORD0;

--- a/src/materials/ActorMultiTexture/vertex.sc
+++ b/src/materials/ActorMultiTexture/vertex.sc
@@ -1,0 +1,75 @@
+$input a_indices, a_color0, a_normal, a_position, a_texcoord0
+#ifdef INSTANCING
+  $input i_data1, i_data2, i_data3
+#endif
+$output v_color0, v_fog, v_light, v_texcoord0, v_edgemap
+
+#include <bgfx_shader.sh>
+#include <MinecraftRenderer.Materials/DynamicUtil.dragonh>
+#include <MinecraftRenderer.Materials/TAAUtil.dragonh>
+#include <newb/main.sh>
+
+uniform vec4 FogControl;
+uniform vec4 FogColor;
+uniform vec4 TileLightColor;
+uniform vec4 OverlayColor;
+uniform mat4 Bones[8];
+uniform vec4 UVAnimation;
+uniform vec4 TimeOfDay;
+uniform vec4 ViewPositionAndTime;
+uniform vec4 CameraPosition;
+uniform vec4 RenderDistance;
+
+void main() {
+  mat4 World = u_model[0];
+
+  World = mul(World, Bones[int(a_indices)]);
+
+  vec2 texcoord0 = a_texcoord0;
+  texcoord0 = applyUvAnimation(texcoord0, UVAnimation);
+
+  vec3 worldPosition;
+  #if defined(INSTANCING)
+    mat4 model = mtxFromCols(i_data1, i_data2, i_data3, vec4(0.0, 0.0, 0.0, 1.0));
+    worldPosition = instMul(model, vec4(a_position, 1.0)).xyz;
+  #else
+    worldPosition = mul(World, vec4(a_position, 1.0)).xyz;
+  #endif
+
+  vec4 position = jitterVertexPosition(worldPosition);
+
+  #if !(defined(DEPTH_ONLY_OPAQUE) || defined(DEPTH_ONLY) || defined(INSTANCING))
+    nl_environment env = nlDetectEnvironment(TimeOfDay.x, FogColor.rgb, FogControl.xyz);
+    nl_skycolor skycol = nlSkyColors(env);
+
+    float relativeDist = position.z/FogControl.z;
+
+    vec3 viewDir = normalize(worldPosition.xyz);
+    viewDir.y = -viewDir.y;
+
+    vec4 fogColor;
+    fogColor.rgb = nlRenderSky(skycol, env, viewDir, ViewPositionAndTime.w, false, false);
+    fogColor.a = nlRenderFogFade(relativeDist, FogColor.rgb, FogControl.xy);
+
+    float netherBiome = 0.0;
+    if (env.nether) {
+      // blend fog with void color
+      netherBiome = smoothstep(0.0, 0.8, FogColor.b);
+      fogColor.rgb = mix(vec3(1.0, 0.169, 0.0), vec3(0.0, 1.0, 0.949), smoothstep(0.0, 0.8, FogColor.b))*1.5;
+      //fogColor.rgb = colorCorrectionInv(FogColor.rgb);
+    }
+
+    vec3 light = nlEntityLighting(skycol, env, a_position, a_normal, worldPosition.xyz, World, TileLightColor, OverlayColor, skycol.horizonEdge, ViewPositionAndTime.w, TimeOfDay.x, RenderDistance.x, CameraPosition.xyz, netherBiome);
+
+    v_texcoord0 = texcoord0;
+    v_color0 = a_color0;
+    v_fog = fogColor;
+    v_light = vec4(light, 1.0);
+    #ifdef NL_ENTITY_EDGE_HIGHLIGHT
+      v_edgemap = nlEntityEdgeHighlightPreprocess(texcoord0);
+    #else
+      v_edgemap = vec4_splat(0.0);
+    #endif
+  #endif
+  gl_Position = position;
+}

--- a/src/materials/project.json
+++ b/src/materials/project.json
@@ -2,7 +2,7 @@
   "base_profile": {
     "platforms": ["ESSL_300"],
     "merge_source": ["../../tool/data/materials"],
-    "include_patterns": [ "Actor", "ActorGlint", "Clouds", "EndSky", "ItemInHandColor", "ItemInHandColorGlint", "ItemInHandTextured", "RenderChunk", "Sky", "Stars", "SunMoon", "Weather" ],
+    "include_patterns": [ "Actor", "ActorGlint", "ActorMultiTexture", "Clouds", "EndSky", "ItemInHandColor", "ItemInHandColorGlint", "ItemInHandTextured", "RenderChunk", "Sky", "Stars", "SunMoon", "Weather" ],
     "exclude_patterns": [".*", "_*"],
     "include_search_paths": ["../../src", "../../include"]
   },

--- a/src/newb/pack_config.toml
+++ b/src/newb/pack_config.toml
@@ -10,7 +10,7 @@ description = '''
 authors = ["devendrn"]
 url = "https://newb-shader.devendrn.com/"
 uuid = "95f774cf-4afa-73e7-a21a-72146307b1d2" # Use https://www.uuidgenerator.net/version4
-materials = ["Sky", "RenderChunk", "Actor", "ActorGlint", "EndSky", "Clouds", "SunMoon", "Weather", "ItemInHandTextured", "ItemInHandColor", "ItemInHandColorGlint", "Stars"]
+materials = ["Sky", "RenderChunk", "Actor", "ActorGlint", "ActorMultiTexture", "EndSky", "Clouds", "SunMoon", "Weather", "ItemInHandTextured", "ItemInHandColor", "ItemInHandColorGlint", "Stars"]
 
 [info] 
 copyright = '''

--- a/tool/util.py
+++ b/tool/util.py
@@ -5,7 +5,7 @@ import platform
 
 CONF_FILE = "tool/data/.builder.pkl"
 NS_DEV_RELEASE = "https://github.com/devendrn/newb-shader/releases/download/dev/"
-NS_DEV_MAT_SRC_URL = NS_DEV_RELEASE + "src-materials-1.26.10.zip"
+NS_DEV_MAT_SRC_URL = NS_DEV_RELEASE + "src-materials-1.26.40.zip"
 NS_DEV_SHADERC_URL_PREFIX = NS_DEV_RELEASE + "shaderc-"
 SHADERC_PATH = os.path.join('tool', 'data', 'shaderc')
 if os.name == 'nt':


### PR DESCRIPTION
We just noticed a few days ago that llamas and horses were no longer affected by Actor material. Therefore, I went fixing it today by finding which material that has something to do with these entities. The reason why horses and llamas (possibly other custom entities) is because mojang now separated theses entities as they have multi-layered textures. Horses have shield (s_MatTexture2) and saddle (s_MatTexture1), while llamas have carpet (s_MatTexture1). On the other hand, I thought pig would be affect by this changes but luckily not, the saddle on the pig was treated as separated draw call compare to the entities I mentioned above. The solution I came up with is to entirely copy everything from Actor (deobfuscated code from Newb) while preserving the original actual behavior of the material.

In addition, the material have a "ColorSecondTexture" flag, but I don't know what is the purpose of this as it has no code block in the obfuscated code from the original material.

Before (Testing by making every actor red):
<img width="1287" height="748" alt="Screenshot From 2026-08-12 11-18-00" src="https://github.com/user-attachments/assets/a46142cc-e569-4da7-84cb-682b83354473" />

After (with ActorMultiTexture material):
<img width="1918" height="856" alt="Screenshot From 2026-08-12 21-25-27" src="https://github.com/user-attachments/assets/3ea0d1a2-3521-4711-84d5-8d4f83f42a9f" />


Latest serialize source materials with ActorMultiTexture: 
[src-materials-1.26.40.zip](https://github.com/user-attachments/files/30983956/src-materials-1.26.40.zip)
